### PR TITLE
Modif typo dans README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,15 @@
 
 ## Français
 
-carpenteR (CARtes PEiNTes En R) est un _package_ dont la vocation est d'agréger les données disponibles de l'Insee et d'en promouvoir l'utilité, en plaçant ces données sur le devant de la scène pour l'utilisateur, et de lui permettre d'en extraire facilement de l'information. Cartographier, probablement l'une des réalisations les plus complètes pour des données, mais pas seulement, et sans payer le coût d'entrée pour trouver le bon lien ou d'importer les données en R.
+`carpenteR` (CARtes PEiNTes En R) est un _package_ dont la vocation est d'agréger les données disponibles de l'Insee et d'en promouvoir l'utilité, en plaçant ces données sur le devant de la scène pour l'utilisateur, et de lui permettre d'en extraire facilement de l'information. Cartographier, probablement l'une des réalisations les plus complètes pour des données, mais pas seulement, et sans payer le coût d'entrée pour trouver le bon lien ou d'importer les données en R.
 
-Pour installer le package, `devtools::pierre-lamarche/carpenteR`.
+Pour installer le package, `
+
+```r
+devtools::install_github('pierre-lamarche/carpenteR')
+```
 
 ## English
-carpenteR (cartes peintes en R, standing for Maps drawn using R in French) is a R package mainly aiming at showing off data available on Insee's website (Insee, for the French Institute for Statistics and Economic Studies), helping the user to put them on stage and extract the information they carry. So not only about creating maps (although this is probably one of the most powerful ways of exploring the richness of the data), but using the data without the painful effort to retrieve them on the website, as well as import them into R's memory.
+
+`carpenteR` (cartes peintes en R, standing for Maps drawn using R in French) is a R package mainly aiming at showing off data available on Insee's website (Insee, for the French Institute for Statistics and Economic Studies), helping the user to put them on stage and extract the information they carry. So not only about creating maps (although this is probably one of the most powerful ways of exploring the richness of the data), but using the data without the painful effort to retrieve them on the website, as well as import them into R's memory.
 


### PR DESCRIPTION
La fonction `pierrelamarche` n'existe pas encore dans `devtools`. Ca ne saurait tarder !